### PR TITLE
Fixed pom.xml and Added log config file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>3.28</version>
         <relativePath/>
     </parent>
-    <artifactId>audit-log-plugin</artifactId>
+    <artifactId>audit-log</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 

--- a/src/main/java/io/jenkins/plugins/audit/listeners/UserLogListener.java
+++ b/src/main/java/io/jenkins/plugins/audit/listeners/UserLogListener.java
@@ -109,4 +109,6 @@ public class UserLogListener extends SecurityListener {
       public static ExtensionList<UserLogListener> all() {
           return ExtensionList.lookup(UserLogListener.class);
       }
+
+
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -16,15 +16,12 @@
 ~ limitations under the license.
 -->
 <Configuration status="ERROR">
-  <properties>
-    <property name="LOG_DIR">${env:JENKINS_HOME}/logs</property>
-  </properties>
+  <Properties>
+    <Property name="LOG_DIR">${env:JENKINS_HOME}/logs</Property>
+</Properties>
   <Appenders>
-
-    </RollingFile>
     <RollingFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
       <RFC5424Layout enterpriseNumber="38143" includeMDC="true" mdcId="RequestContext" appName="Log4j-audit-plugin" mdcPrefix="" newLine="true"/>
-
     </RollingFile>
   </Appenders>
   <Loggers>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements. See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache license, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License. You may obtain a copy of the License at
+~
+~      http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the license for the specific language governing permissions and
+~ limitations under the license.
+-->
+<Configuration status="ERROR">
+  <properties>
+    <property name="LOG_DIR">${env:JENKINS_HOME}/logs</property>
+  </properties>
+  <Appenders>
+
+    </RollingFile>
+    <RollingFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
+      <RFC5424Layout enterpriseNumber="38143" includeMDC="true" mdcId="RequestContext" appName="Log4j-audit-plugin" mdcPrefix="" newLine="true"/>
+
+    </RollingFile>
+  </Appenders>
+  <Loggers>
+    <Logger name="AuditLogger" level="trace" additivity="false">
+      <AppenderRef ref="audit"/>
+    </Logger>
+  </Loggers>
+</Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -22,9 +22,7 @@
   <Appenders>
     <RollingRandomAccessFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
       <RFC5424Layout enterpriseNumber="38143" includeMDC="true" mdcId="RequestContext" appName="Log4j-audit-plugin" mdcPrefix="" newLine="true"/>
-      <Policies>
-        <SizeBasedTriggeringPolicy size="20 MB"/>
-      </Policies>
+      <SizeBasedTriggeringPolicy size="20 MB"/>
     </RollingRandomAccessFile>
   </Appenders>
   <Loggers>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,23 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ~ Licensed to the Apache Software Foundation (ASF) under one or more ~ contributor license agreements. See the NOTICE file distributed with ~ this work for additional information regarding copyright ownership. ~ The ASF licenses this file to You
-under the Apache license, Version 2.0 ~ (the "License"); you may not use this file except in compliance with ~ the License. You may obtain a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by applicable law
-or agreed to in writing, software ~ distributed under the License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. ~ See the license for the specific language governing permissions and ~
-limitations under the license. -->
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements. See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache license, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License. You may obtain a copy of the License at
+~
+~      http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the license for the specific language governing permissions and
+~ limitations under the license.
+-->
 <Configuration status="ERROR">
-    <Properties>
-        <Property name="LOG_DIR">${env:JENKINS_HOME}/logs</Property>
-    </Properties>
-    <Appenders>
-        <RollingRandomAccessFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
-            <RFC5424Layout enterpriseNumber="38143" includeMDC="true" mdcId="RequestContext" appName="Log4j-audit-plugin" mdcPrefix="" newLine="true"/>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="30 MB"/>
-            </Policies>
-        </RollingRandomAccessFile>
-    </Appenders>
-    <Loggers>
-        <Logger name="AuditLogger" level="trace" additivity="false">
-            <AppenderRef ref="audit"/>
-        </Logger>
-    </Loggers>
+  <Properties>
+    <Property name="LOG_DIR">${env:JENKINS_HOME}/logs</Property>
+  </Properties>
+  <Appenders>
+    <RollingRandomAccessFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
+      <RFC5424Layout enterpriseNumber="38143" includeMDC="true" mdcId="RequestContext" appName="Log4j-audit-plugin" mdcPrefix="" newLine="true"/>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="20 MB"/>
+      </Policies>
+    </RollingRandomAccessFile>
+  </Appenders>
+  <Loggers>
+    <Logger name="AuditLogger" level="trace" additivity="false">
+      <AppenderRef ref="audit"/>
+    </Logger>
+  </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,32 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-~ Licensed to the Apache Software Foundation (ASF) under one or more
-~ contributor license agreements. See the NOTICE file distributed with
-~ this work for additional information regarding copyright ownership.
-~ The ASF licenses this file to You under the Apache license, Version 2.0
-~ (the "License"); you may not use this file except in compliance with
-~ the License. You may obtain a copy of the License at
-~
-~      http://www.apache.org/licenses/LICENSE-2.0
-~
-~ Unless required by applicable law or agreed to in writing, software
-~ distributed under the License is distributed on an "AS IS" BASIS,
-~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-~ See the license for the specific language governing permissions and
-~ limitations under the license.
--->
+<!-- ~ Licensed to the Apache Software Foundation (ASF) under one or more ~ contributor license agreements. See the NOTICE file distributed with ~ this work for additional information regarding copyright ownership. ~ The ASF licenses this file to You
+under the Apache license, Version 2.0 ~ (the "License"); you may not use this file except in compliance with ~ the License. You may obtain a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by applicable law
+or agreed to in writing, software ~ distributed under the License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. ~ See the license for the specific language governing permissions and ~
+limitations under the license. -->
 <Configuration status="ERROR">
-  <Properties>
-    <Property name="LOG_DIR">${env:JENKINS_HOME}/logs</Property>
-</Properties>
-  <Appenders>
-    <RollingFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
-      <RFC5424Layout enterpriseNumber="38143" includeMDC="true" mdcId="RequestContext" appName="Log4j-audit-plugin" mdcPrefix="" newLine="true"/>
-    </RollingFile>
-  </Appenders>
-  <Loggers>
-    <Logger name="AuditLogger" level="trace" additivity="false">
-      <AppenderRef ref="audit"/>
-    </Logger>
-  </Loggers>
+    <Properties>
+        <Property name="LOG_DIR">${env:JENKINS_HOME}/logs</Property>
+    </Properties>
+    <Appenders>
+        <RollingRandomAccessFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
+            <RFC5424Layout enterpriseNumber="38143" includeMDC="true" mdcId="RequestContext" appName="Log4j-audit-plugin" mdcPrefix="" newLine="true"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="30 MB"/>
+            </Policies>
+        </RollingRandomAccessFile>
+    </Appenders>
+    <Loggers>
+        <Logger name="AuditLogger" level="trace" additivity="false">
+            <AppenderRef ref="audit"/>
+        </Logger>
+    </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -23,7 +23,7 @@
     <RollingRandomAccessFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
       <RFC5424Layout enterpriseNumber="38143" includeMDC="true" mdcId="RequestContext" appName="Log4j-audit-plugin" mdcPrefix="" newLine="true"/>
       <Policies>
-        <SizeBasedTriggeringPolicy size="20 MB"/>
+        <SizeBasedTriggeringPolicy size="30 MB"/>
       </Policies>
     </RollingRandomAccessFile>
   </Appenders>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -22,7 +22,9 @@
   <Appenders>
     <RollingRandomAccessFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
       <RFC5424Layout enterpriseNumber="38143" includeMDC="true" mdcId="RequestContext" appName="Log4j-audit-plugin" mdcPrefix="" newLine="true"/>
-      <SizeBasedTriggeringPolicy size="20 MB"/>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="20 MB"/>
+      </Policies>
     </RollingRandomAccessFile>
   </Appenders>
   <Loggers>


### PR DESCRIPTION
See [Hosting-670](https://issues.jenkins-ci.org/browse/HOSTING-670) and [JENKINS-54636](https://issues.jenkins-ci.org/browse/JENKINS-54636).

- Edited `pom.xml` file as per correction suggested by Alex Earl.
- Added default log configuration file which uses RFC5424 layout to output audit events.


Desired Reviewers:
@jvz 