### PR TITLE
Refiled - Added default log configuration file

### DIFF
--- a/src/main/java/io/jenkins/plugins/audit/listeners/UserLogListener.java
+++ b/src/main/java/io/jenkins/plugins/audit/listeners/UserLogListener.java
@@ -80,6 +80,8 @@ public class UserLogListener extends SecurityListener {
         Login login = LogEventFactory.getEvent(Login.class);
 
         RequestContext.setIpAddress(Stapler.getCurrentRequest().getRemoteAddr());
+        RequestContext.setNodeName("master");
+        RequestContext.getRequestId();
         login.setUserId(username);
         login.setTimestamp(currentTime);
         login.logEvent();
@@ -96,6 +98,8 @@ public class UserLogListener extends SecurityListener {
          String currentTime = Instant.now().toString();
          Logout logout = LogEventFactory.getEvent(Logout.class);
 
+         RequestContext.setNodeName("master");
+         RequestContext.getRequestId();
          RequestContext.setIpAddress(Stapler.getCurrentRequest().getRemoteAddr());
          logout.setUserId(username);
          logout.setTimestamp(currentTime);

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements. See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache license, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License. You may obtain a copy of the License at
+~
+~      http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the license for the specific language governing permissions and
+~ limitations under the license.
+-->
+<Configuration status="ERROR">
+    <Properties>
+        <Property name="LOG_DIR">${env:JENKINS_HOME}/logs</Property>
+    </Properties>
+    <Appenders>
+        <RollingRandomAccessFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
+            <JsonLayout properties="true" locationInfo="true" eventEol="true"></JsonLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="20 MB"/>
+            </Policies>
+        </RollingRandomAccessFile>
+    </Appenders>
+    <Loggers>
+        <Logger name="AuditLogger" level="trace" additivity="false">
+            <AppenderRef ref="audit"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -21,7 +21,7 @@
     </Properties>
     <Appenders>
         <RollingRandomAccessFile name="audit" fileName="${LOG_DIR}/audit.log" filePattern="${LOG_DIR}/archive/audit.log.%d{yyyyMMdd_HHmmss}-%i">
-            <JsonLayout properties="true" locationInfo="true" eventEol="true"></JsonLayout>
+            <JsonLayout properties="true" locationInfo="true"></JsonLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>
             </Policies>


### PR DESCRIPTION
See [JENKINS-54636](https://issues.jenkins-ci.org/browse/JENKINS-54636).

- Added default log configuration file which uses JSON layout to output audit events.
- Fixed errors 'ThreadContext does not contain required key nodeName' and 'ThreadContext does not contain required key requestId'


Desired Reviewers:
@jvz 